### PR TITLE
refactor: replace redis with valkey

### DIFF
--- a/config/spotless/android.importorder
+++ b/config/spotless/android.importorder
@@ -21,4 +21,4 @@
 3=\#dalvik
 2=\#com.android
 1=\#androidx
-0=\#redis
+0=\#valkey

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
               <createDependencyReducedPom>true</createDependencyReducedPom>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>com.example.redis.cli.RedisCli</mainClass>
+                  <mainClass>com.example.valkey.cli.ValkeyCli</mainClass>
                 </transformer>
               </transformers>
             </configuration>

--- a/src/main/java/com/example/redis/core/RedisUnavailableException.java
+++ b/src/main/java/com/example/redis/core/RedisUnavailableException.java
@@ -1,5 +1,0 @@
-package com.example.redis.core;
-
-public class RedisUnavailableException extends RuntimeException {
-  public RedisUnavailableException(String message, Throwable cause) { super(message, cause); }
-}

--- a/src/main/java/com/example/valkey/cli/ValkeyCli.java
+++ b/src/main/java/com/example/valkey/cli/ValkeyCli.java
@@ -1,11 +1,11 @@
-package com.example.redis.cli;
+package com.example.valkey.cli;
 
-import com.example.redis.core.MessagePublisher;
-import com.example.redis.core.MessageSubscriber;
-import com.example.redis.jedis.JedisMessagePublisher;
-import com.example.redis.jedis.JedisMessageSubscriber;
-import com.example.redis.jedis.JedisPools;
-import com.example.redis.jedis.RedisProps;
+import com.example.valkey.core.MessagePublisher;
+import com.example.valkey.core.MessageSubscriber;
+import com.example.valkey.jedis.JedisMessagePublisher;
+import com.example.valkey.jedis.JedisMessageSubscriber;
+import com.example.valkey.jedis.JedisPools;
+import com.example.valkey.jedis.ValkeyProps;
 import info.picocli.CommandLine;
 import info.picocli.CommandLine.*;
 import java.util.UUID;
@@ -14,17 +14,17 @@ import org.slf4j.MDC;
 import redis.clients.jedis.JedisPool;
 
 @Command(
-    name = "redis-cli",
-    version = "redis-pubsub 0.1.0",
+    name = "valkey-cli",
+    version = "valkey-pubsub 0.1.0",
     mixinStandardHelpOptions = true,
-    subcommands = {RedisCli.Publish.class, RedisCli.Subscribe.class})
-public final class RedisCli implements Runnable {
+    subcommands = {ValkeyCli.Publish.class, ValkeyCli.Subscribe.class})
+  public final class ValkeyCli implements Runnable {
 
   @Option(names = "--trace-id", description = "trace id for logs (default: random uuid)")
   String traceId;
 
   public static void main(String[] args) {
-    int exit = new CommandLine(new RedisCli()).execute(args);
+      int exit = new CommandLine(new ValkeyCli()).execute(args);
     System.exit(exit);
   }
 
@@ -33,8 +33,8 @@ public final class RedisCli implements Runnable {
     // ルートで何もしない（help表示は picocli が対応）
   }
 
-  static RedisProps buildProps(Common c) {
-    return new RedisProps(
+    static ValkeyProps buildProps(Common c) {
+      return new ValkeyProps(
         c.host, c.port, c.ssl, c.username, c.password, c.database, c.timeoutMillis,
         c.poolMaxTotal, c.poolMaxIdle, c.poolMinIdle);
   }
@@ -53,15 +53,15 @@ public final class RedisCli implements Runnable {
   }
 
   @Command(name = "publish", description = "Publish a message to a channel")
-  static final class Publish extends Common implements Callable<Integer> {
-    @ParentCommand RedisCli parent;
+    static final class Publish extends Common implements Callable<Integer> {
+      @ParentCommand ValkeyCli parent;
 
     @Parameters(index = "0", paramLabel = "CHANNEL") String channel;
     @Parameters(index = "1", paramLabel = "MESSAGE") String message;
 
     @Override
     public Integer call() {
-      String tid = parent.traceId != null ? parent.traceId : UUID.randomUUID().toString();
+        String tid = parent.traceId != null ? parent.traceId : UUID.randomUUID().toString();
       MDC.put("traceId", tid);
       try (JedisPool pool = JedisPools.create(buildProps(this))) {
         MessagePublisher pub = new JedisMessagePublisher(pool);
@@ -78,8 +78,8 @@ public final class RedisCli implements Runnable {
   }
 
   @Command(name = "subscribe", description = "Subscribe and print messages")
-  static final class Subscribe extends Common implements Callable<Integer> {
-    @ParentCommand RedisCli parent;
+    static final class Subscribe extends Common implements Callable<Integer> {
+      @ParentCommand ValkeyCli parent;
 
     @Parameters(index = "0", paramLabel = "CHANNEL") String channel;
 

--- a/src/main/java/com/example/valkey/core/MessagePublisher.java
+++ b/src/main/java/com/example/valkey/core/MessagePublisher.java
@@ -1,4 +1,4 @@
-package com.example.redis.core;
+package com.example.valkey.core;
 
 public interface MessagePublisher {
   /** @return publish に反応した subscriber 数 */

--- a/src/main/java/com/example/valkey/core/MessageSubscriber.java
+++ b/src/main/java/com/example/valkey/core/MessageSubscriber.java
@@ -1,4 +1,4 @@
-package com.example.redis.core;
+package com.example.valkey.core;
 
 public interface MessageSubscriber {
   @FunctionalInterface

--- a/src/main/java/com/example/valkey/core/PublishException.java
+++ b/src/main/java/com/example/valkey/core/PublishException.java
@@ -1,4 +1,4 @@
-package com.example.redis.core;
+package com.example.valkey.core;
 
 public class PublishException extends RuntimeException {
   public PublishException(String message, Throwable cause) { super(message, cause); }

--- a/src/main/java/com/example/valkey/core/ValkeyUnavailableException.java
+++ b/src/main/java/com/example/valkey/core/ValkeyUnavailableException.java
@@ -1,0 +1,7 @@
+package com.example.valkey.core;
+
+public class ValkeyUnavailableException extends RuntimeException {
+  public ValkeyUnavailableException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/com/example/valkey/jedis/JedisMessagePublisher.java
+++ b/src/main/java/com/example/valkey/jedis/JedisMessagePublisher.java
@@ -1,8 +1,8 @@
-package com.example.redis.jedis;
+package com.example.valkey.jedis;
 
-import com.example.redis.core.MessagePublisher;
-import com.example.redis.core.PublishException;
-import com.example.redis.core.RedisUnavailableException;
+import com.example.valkey.core.MessagePublisher;
+import com.example.valkey.core.PublishException;
+import com.example.valkey.core.ValkeyUnavailableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -30,8 +30,8 @@ public final class JedisMessagePublisher implements MessagePublisher {
       }
       return n;
     } catch (JedisExhaustedPoolException | JedisConnectionException e) {
-      log.error("redis unavailable on publish to '{}': {}", channel, e.toString());
-      throw new RedisUnavailableException("redis unavailable", e);
+        log.error("valkey unavailable on publish to '{}': {}", channel, e.toString());
+        throw new ValkeyUnavailableException("valkey unavailable", e);
     } catch (JedisDataException e) {
       log.error("publish data error on '{}'", channel, e);
       throw new PublishException("publish data error", e);

--- a/src/main/java/com/example/valkey/jedis/JedisMessageSubscriber.java
+++ b/src/main/java/com/example/valkey/jedis/JedisMessageSubscriber.java
@@ -1,7 +1,8 @@
 // jedis/JedisMessageSubscriber.java
-package com.example.redis.jedis;
+package com.example.valkey.jedis;
 
-import com.example.redis.core.MessageSubscriber;
+import com.example.valkey.core.MessageSubscriber;
+import com.example.valkey.jedis.ValkeyProps;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
@@ -11,11 +12,13 @@ import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPubSub;
 
-public final class JedisMessageSubscriber implements MessageSubscriber {
-  private static final Logger log = LoggerFactory.getLogger(JedisMessageSubscriber.class);
-  private final RedisProps props;
+  public final class JedisMessageSubscriber implements MessageSubscriber {
+    private static final Logger log = LoggerFactory.getLogger(JedisMessageSubscriber.class);
+    private final ValkeyProps props;
 
-  public JedisMessageSubscriber(RedisProps props) { this.props = Objects.requireNonNull(props); }
+    public JedisMessageSubscriber(ValkeyProps props) {
+      this.props = Objects.requireNonNull(props);
+    }
 
   @Override
   public SubscriptionHandle subscribe(String channel, Handler handler) {
@@ -54,8 +57,8 @@ public final class JedisMessageSubscriber implements MessageSubscriber {
               } finally {
                 log.info("subscribe end channel='{}'", channel);
               }
-            },
-            "redis-sub-" + channel);
+              },
+              "valkey-sub-" + channel);
 
     t.setDaemon(true);
     t.start();

--- a/src/main/java/com/example/valkey/jedis/JedisPools.java
+++ b/src/main/java/com/example/valkey/jedis/JedisPools.java
@@ -1,4 +1,4 @@
-package com.example.redis.jedis;
+package com.example.valkey.jedis;
 
 import java.time.Duration;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
@@ -10,7 +10,7 @@ import redis.clients.jedis.JedisPool;
 public final class JedisPools {
   private JedisPools() {}
 
-  public static JedisPool create(RedisProps p) {
+  public static JedisPool create(ValkeyProps p) {
     var hap = new HostAndPort(p.host(), p.port());
     JedisClientConfig cfg =
         DefaultJedisClientConfig.builder()

--- a/src/main/java/com/example/valkey/jedis/ValkeyProps.java
+++ b/src/main/java/com/example/valkey/jedis/ValkeyProps.java
@@ -1,6 +1,6 @@
-package com.example.redis.jedis;
+package com.example.valkey.jedis;
 
-public record RedisProps(
+public record ValkeyProps(
     String host,
     int port,
     boolean ssl,
@@ -12,7 +12,7 @@ public record RedisProps(
     int poolMaxIdle,
     int poolMinIdle) {
 
-  public static RedisProps defaults() {
-    return new RedisProps("127.0.0.1", 6379, false, null, null, 0, 5000, 32, 16, 4);
+  public static ValkeyProps defaults() {
+    return new ValkeyProps("127.0.0.1", 6379, false, null, null, 0, 5000, 32, 16, 4);
   }
 }

--- a/src/main/test/java/com/example/valkey/jedis/ValkeyPubSubIT.java
+++ b/src/main/test/java/com/example/valkey/jedis/ValkeyPubSubIT.java
@@ -1,9 +1,9 @@
-package com.example.redis.jedis;
+package com.example.valkey.jedis;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.example.redis.core.MessagePublisher;
-import com.example.redis.core.MessageSubscriber;
+import com.example.valkey.core.MessagePublisher;
+import com.example.valkey.core.MessageSubscriber;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.*;
@@ -13,20 +13,20 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import redis.clients.jedis.JedisPool;
 
 @Testcontainers
-class RedisPubSubIT {
+class ValkeyPubSubIT {
 
   @Container
-  static GenericContainer<?> redis =
-      new GenericContainer<>("redis:7-alpine").withExposedPorts(6379);
+  static GenericContainer<?> valkey =
+      new GenericContainer<>("valkey/valkey:7-alpine").withExposedPorts(6379);
 
   @Test
   void publish_and_receive() throws Exception {
-    var props =
-        new RedisProps(redis.getHost(), redis.getFirstMappedPort(), false, null, null, 0, 5000, 8, 4, 1);
+      var props =
+          new ValkeyProps(valkey.getHost(), valkey.getFirstMappedPort(), false, null, null, 0, 5000, 8, 4, 1);
 
     try (JedisPool pool = JedisPools.create(props)) {
-      MessagePublisher pub = new JedisMessagePublisher(pool);
-      MessageSubscriber sub = new JedisMessageSubscriber(props);
+        MessagePublisher pub = new JedisMessagePublisher(pool);
+        MessageSubscriber sub = new JedisMessageSubscriber(props);
 
       String channel = "it";
       var latch = new CountDownLatch(1);


### PR DESCRIPTION
## Summary
- rename redis packages and classes to valkey
- update test container to valkey image
- adjust Maven shade plugin main class

## Testing
- `mvn -q test` *(fails: 'dependencies.dependency.version' for org.slf4j:slf4j-api and ch.qos.logback:logback-classic is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c5efecd3b4832593b7cabe0f5c1108