### PR TITLE
Add versions for logging dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,8 @@
     <jedis.version>5.1.4</jedis.version>
     <picocli.version>4.7.6</picocli.version>
     <spotless.version>2.43.0</spotless.version>
+    <slf4j.version>2.0.12</slf4j.version>
+    <logback.version>1.5.6</logback.version>
   </properties>
 
   <dependencies>
@@ -30,10 +32,12 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
     </dependency>
 
     <!-- Test -->


### PR DESCRIPTION
## Summary
- declare slf4j and logback versions in pom

## Testing
- `mvn -q test` *(fails: Could not transfer artifact com.diffplug.spotless:spotless-maven-plugin:pom:2.43.0 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f0e7ea5c8325af7d767c5ebf5571