### PR TITLE
Add Makefile for Maven build and test tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+MVN ?= mvn
+.DEFAULT_GOAL := help
+
+.PHONY: build test build-skip-tests unit-test clean help
+
+build:
+	$(MVN) package
+
+test:
+	$(MVN) test
+
+build-skip-tests:
+	$(MVN) package -DskipTests
+
+unit-test:
+	test -n "$(TEST)" || (echo "TEST is not set. Use 'make unit-test TEST=ClassName'" && exit 1)
+	$(MVN) -Dtest=$(TEST) test
+
+clean:
+	$(MVN) clean
+
+help:
+	@echo "Makefile for Maven build"
+	@echo
+	@echo "Targets:"
+	@echo "  build              Build the project with tests"
+	@echo "  test               Run all tests"
+	@echo "  build-skip-tests   Build the project without tests"
+	@echo "  unit-test TEST=<name>  Run a single unit test class"
+	@echo "  clean              Remove build artifacts"
+	@echo "  help               Show this help"


### PR DESCRIPTION
## Summary
- add Makefile with targets for building, testing, skipping tests, running a single unit test, cleaning, and help

## Testing
- `make build` *(fails: Could not transfer artifact com.diffplug.spotless:spotless-maven-plugin:pom:2.43.0 from/to central: Network is unreachable)*
- `make test` *(fails: Could not transfer artifact com.diffplug.spotless:spotless-maven-plugin:pom:2.43.0 from/to central: Network is unreachable)*
- `make build-skip-tests` *(fails: Could not transfer artifact com.diffplug.spotless:spotless-maven-plugin:pom:2.43.0 from/to central: Network is unreachable)*
- `make unit-test TEST=ValkeyPubSubIT` *(fails: Could not transfer artifact com.diffplug.spotless:spotless-maven-plugin:pom:2.43.0 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f22b54888325a312737c17c9a1e4