### PR TITLE
feat(cli): add exception reporter

### DIFF
--- a/src/main/java/com/example/valkey/cli/ExceptionReporter.java
+++ b/src/main/java/com/example/valkey/cli/ExceptionReporter.java
@@ -1,0 +1,30 @@
+package com.example.valkey.cli;
+
+final class ExceptionReporter {
+
+    private ExceptionReporter() {}
+
+    static void print(Throwable t) {
+        Throwable root = rootCause(t);
+        StackTraceElement[] trace = root.getStackTrace();
+        String place;
+        if (trace != null && trace.length > 0) {
+            StackTraceElement e = trace[0];
+            place = e.getClassName() + "." + e.getMethodName() +
+                    "(" + e.getFileName() + ":" + e.getLineNumber() + ")";
+        } else {
+            place = "unknown";
+        }
+        String message = root.getClass().getSimpleName() +
+                (root.getMessage() != null ? ": " + root.getMessage() : "");
+        System.err.println(message + " at " + place);
+    }
+
+    private static Throwable rootCause(Throwable t) {
+        Throwable r = t;
+        while (r.getCause() != null) {
+            r = r.getCause();
+        }
+        return r;
+    }
+}

--- a/src/main/java/com/example/valkey/cli/ValkeyCli.java
+++ b/src/main/java/com/example/valkey/cli/ValkeyCli.java
@@ -24,8 +24,19 @@ public final class ValkeyCli implements Runnable {
     String traceId;
 
     public static void main(String[] args) {
-        int exit = new CommandLine(new ValkeyCli()).execute(args);
+        CommandLine cmd = new CommandLine(new ValkeyCli());
+        cmd.setExecutionExceptionHandler(new ShortErrorHandler());
+        int exit = cmd.execute(args);
         System.exit(exit);
+    }
+
+    static final class ShortErrorHandler implements IExecutionExceptionHandler {
+        @Override
+        public int handleExecutionException(
+                Exception ex, CommandLine commandLine, ParseResult parseResult) {
+            ExceptionReporter.print(ex);
+            return commandLine.getCommandSpec().exitCodeOnExecutionException();
+        }
     }
 
     @Override
@@ -103,7 +114,7 @@ public final class ValkeyCli implements Runnable {
                 System.out.printf("OK receivers=%d traceId=%s%n", n, tid);
                 return 0;
             } catch (Exception e) {
-                e.printStackTrace();
+                ExceptionReporter.print(e);
                 return 1;
             } finally {
                 MDC.remove("traceId");


### PR DESCRIPTION
## Summary
- show concise exception info on CLI errors
- hook picocli execution handler to use the concise reporter

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Could not transfer artifact com.diffplug.spotless:spotless-maven-plugin:pom:2.43.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fce340288325bd69129441061542