### PR TITLE
docs: document Jedis message publisher

### DIFF
--- a/src/main/java/com/example/valkey/jedis/JedisMessagePublisher.java
+++ b/src/main/java/com/example/valkey/jedis/JedisMessagePublisher.java
@@ -12,15 +12,33 @@ import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.exceptions.JedisException;
 
+/**
+ * Jedis-based implementation of {@link MessagePublisher} that publishes messages to
+ * Valkey using a {@link JedisPool}.
+ */
 public final class JedisMessagePublisher implements MessagePublisher {
     private static final Logger log = LoggerFactory.getLogger(JedisMessagePublisher.class);
     private final JedisPool pool;
 
+    /**
+     * Create a publisher backed by the given Jedis connection pool.
+     *
+     * @param pool Jedis connection pool
+     */
     public JedisMessagePublisher(JedisPool pool) {
         this.pool = pool;
     }
 
     @Override
+    /**
+     * Publish a message to a channel.
+     *
+     * @param channel channel to publish to
+     * @param message message body
+     * @return number of receivers
+     * @throws ValkeyUnavailableException if Valkey is not reachable
+     * @throws PublishException if the publish operation fails
+     */
     public long publish(String channel, String message) {
         try (Jedis j = pool.getResource()) {
             Long recv = j.publish(channel, message);


### PR DESCRIPTION
## Summary
- document JedisMessagePublisher as Jedis-based publisher
- add Javadoc for JedisPool constructor parameter
- expand publish method documentation with parameters, return, and exceptions

## Testing
- `make fmt` *(fails: No plugin found for prefix 'spotless')*
- `make test` *(fails: Plugin com.diffplug.spotless:spotless-maven-plugin:2.43.0 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fe9c9bc483258278b608f86c7885