### PR TITLE
docs: document ValkeyProps fields and defaults

### DIFF
--- a/src/main/java/com/example/valkey/jedis/ValkeyProps.java
+++ b/src/main/java/com/example/valkey/jedis/ValkeyProps.java
@@ -1,5 +1,19 @@
 package com.example.valkey.jedis;
 
+/**
+ * Connection configuration for Valkey.
+ *
+ * @param host         Valkey server hostname
+ * @param port         Valkey server port
+ * @param ssl          whether to enable TLS
+ * @param username     username for authentication or {@code null}
+ * @param password     password for authentication or {@code null}
+ * @param database     zero-indexed database number
+ * @param timeoutMillis socket timeout in milliseconds
+ * @param poolMaxTotal maximum total connections in the pool
+ * @param poolMaxIdle  maximum idle connections in the pool
+ * @param poolMinIdle  minimum idle connections in the pool
+ */
 public record ValkeyProps(
         String host,
         int port,
@@ -12,6 +26,14 @@ public record ValkeyProps(
         int poolMaxIdle,
         int poolMinIdle) {
 
+    /**
+     * Create a {@code ValkeyProps} instance using library defaults.
+     * Defaults use localhost on port {@code 6379}, disable SSL, no authentication,
+     * database {@code 0}, a 5-second timeout, and a connection pool of
+     * 32 maximum total connections with 16 maximum idle and 4 minimum idle.
+     *
+     * @return default property values
+     */
     public static ValkeyProps defaults() {
         return new ValkeyProps("127.0.0.1", 6379, false, null, null, 0, 5000, 32, 16, 4);
     }


### PR DESCRIPTION
## Summary
- document ValkeyProps configuration record and explain each field
- describe default property values returned by defaults()

## Testing
- `mvn -q test` *(fails: Could not transfer artifact com.diffplug.spotless:spotless-maven-plugin:pom:2.43.0 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fe9c25dc83259dacb291b6285bd5