### PR TITLE
docs(core): describe async subscription behavior

### DIFF
--- a/src/main/java/com/example/valkey/core/MessageSubscriber.java
+++ b/src/main/java/com/example/valkey/core/MessageSubscriber.java
@@ -1,15 +1,41 @@
 package com.example.valkey.core;
 
+/**
+ * Provides asynchronous subscriptions to channels.
+ * Implementations deliver messages to registered handlers without blocking the caller.
+ */
 public interface MessageSubscriber {
+
+    /**
+     * Callback invoked whenever a subscribed channel receives a message.
+     */
     @FunctionalInterface
     interface Handler {
+        /**
+         * Handle a message published to a channel.
+         *
+         * @param channel the channel from which the message was received
+         * @param message the payload delivered on the channel
+         */
         void onMessage(String channel, String message);
     }
 
-    /** 非同期で購読を開始し、停止用ハンドルを返す */
+    /**
+     * Begin an asynchronous subscription and return a handle that can stop it.
+     *
+     * @param channel channel to subscribe to
+     * @param handler callback invoked for each received message
+     * @return handle used to close the subscription
+     */
     SubscriptionHandle subscribe(String channel, Handler handler);
 
+    /**
+     * Handle used to manage an active subscription.
+     */
     interface SubscriptionHandle extends AutoCloseable {
+        /**
+         * Cancel the subscription and release any underlying resources.
+         */
         @Override
         void close();
     }


### PR DESCRIPTION
## Summary
- document asynchronous subscription usage in `MessageSubscriber`

## Testing
- `mvn -q test` *(fails: Plugin com.diffplug.spotless:spotless-maven-plugin:2.43.0 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fe9b38d883258615fde2f502f69e