### PR TITLE
docs(core): document exception classes

### DIFF
--- a/src/main/java/com/example/valkey/core/PublishException.java
+++ b/src/main/java/com/example/valkey/core/PublishException.java
@@ -1,6 +1,15 @@
 package com.example.valkey.core;
 
+/**
+ * Thrown when a publish operation fails to deliver a message to Valkey.
+ */
 public class PublishException extends RuntimeException {
+    /**
+     * Creates a new exception with the specified detail message and cause.
+     *
+     * @param message description of the error
+     * @param cause the underlying cause of the failure
+     */
     public PublishException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/com/example/valkey/core/ValkeyUnavailableException.java
+++ b/src/main/java/com/example/valkey/core/ValkeyUnavailableException.java
@@ -1,6 +1,15 @@
 package com.example.valkey.core;
 
+/**
+ * Indicates that the Valkey server cannot be reached or is otherwise unavailable.
+ */
 public class ValkeyUnavailableException extends RuntimeException {
+    /**
+     * Creates a new exception with the specified detail message and cause.
+     *
+     * @param message description of the error
+     * @param cause the underlying cause of the failure
+     */
     public ValkeyUnavailableException(String message, Throwable cause) {
         super(message, cause);
     }


### PR DESCRIPTION
## Summary
- add class-level Javadoc for ValkeyUnavailableException
- add class-level Javadoc for PublishException

## Testing
- `mvn -q com.diffplug.spotless:spotless-maven-plugin:2.43.0:apply` *(fails: Could not transfer artifact com.diffplug.spotless:spotless-maven-plugin:pom:2.43.0 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*
- `mvn -q test` *(fails: Could not transfer artifact com.diffplug.spotless:spotless-maven-plugin:pom:2.43.0 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fe99ada4832594d034269b16fab0