### PR TITLE
docs: add MyPublisher usage and exception handling example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,48 @@ Subscribe to a channel:
 java -jar target/valkey-pubsub-0.1.0.jar subscribe --host 127.0.0.1 --port 6379 test
 ```
 
+### Programmatic Example
+The project can also be used directly from application code. The following class keeps a single Jedis pool and exposes a simple `publish` method:
+
+```java
+// MyPublisher.java
+import com.example.valkey.core.MessagePublisher;
+import com.example.valkey.jedis.*;
+import redis.clients.jedis.JedisPool;
+
+public final class MyPublisher implements AutoCloseable {
+    private final JedisPool pool;
+    private final MessagePublisher publisher;
+
+    public MyPublisher(ValkeyProps props) {
+        this.pool = JedisPools.create(props);
+        this.publisher = new JedisMessagePublisher(pool);
+    }
+
+    public long publish(String channel, String message) {
+        return publisher.publish(channel, message);
+    }
+
+    @Override
+    public void close() {
+        pool.close();
+    }
+}
+```
+
+Call it from other code and handle the runtime exceptions declared by `MessagePublisher`:
+
+```java
+ValkeyProps props = ValkeyProps.defaults();
+try (MyPublisher pub = new MyPublisher(props)) {
+    pub.publish("test", "{\"robotId\":\"R1\"}");
+} catch (ValkeyUnavailableException | PublishException e) {
+    // handle connection or publish failures
+} catch (NullPointerException e) {
+    // handle null channel or message
+}
+```
+
 ### License
 This project is licensed under the MIT License. See [LICENSE](LICENSE).
 


### PR DESCRIPTION
## Summary
- document MyPublisher wrapper class
- show how to catch publish-related exceptions

## Testing
- `mvn -q test` *(fails: PluginResolutionException, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c600e6099883259507d1bb8bbafd6f